### PR TITLE
Client publisher, ICounter using expando

### DIFF
--- a/ElasticStatisticsProviderTests/ElasticStatisticsProviderTests.csproj
+++ b/ElasticStatisticsProviderTests/ElasticStatisticsProviderTests.csproj
@@ -1,0 +1,83 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{FF4A19D7-6EAE-40C5-9A4C-8013A38A3FF8}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>ElasticStatisticsProviderTests</RootNamespace>
+    <AssemblyName>ElasticStatisticsProviderTests</AssemblyName>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">10.0</VisualStudioVersion>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+    <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\$(VisualStudioVersion)\UITestExtensionPackages</ReferencePath>
+    <IsCodedUITest>False</IsCodedUITest>
+    <TestProjectType>UnitTest</TestProjectType>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+  </ItemGroup>
+  <Choose>
+    <When Condition="('$(VisualStudioVersion)' == '10.0' or '$(VisualStudioVersion)' == '') and '$(TargetFrameworkVersion)' == 'v3.5'">
+      <ItemGroup>
+        <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework, Version=10.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
+      </ItemGroup>
+    </When>
+    <Otherwise>
+      <ItemGroup>
+        <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework" />
+      </ItemGroup>
+    </Otherwise>
+  </Choose>
+  <ItemGroup>
+    <Compile Include="UnitTest1.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <Choose>
+    <When Condition="'$(VisualStudioVersion)' == '10.0' And '$(IsCodedUITest)' == 'True'">
+      <ItemGroup>
+        <Reference Include="Microsoft.VisualStudio.QualityTools.CodedUITestFramework, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+          <Private>False</Private>
+        </Reference>
+        <Reference Include="Microsoft.VisualStudio.TestTools.UITest.Common, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+          <Private>False</Private>
+        </Reference>
+        <Reference Include="Microsoft.VisualStudio.TestTools.UITest.Extension, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+          <Private>False</Private>
+        </Reference>
+        <Reference Include="Microsoft.VisualStudio.TestTools.UITesting, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+          <Private>False</Private>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
+  <Import Project="$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets" Condition="Exists('$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets')" />
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/ElasticStatisticsProviderTests/Properties/AssemblyInfo.cs
+++ b/ElasticStatisticsProviderTests/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("ElasticStatisticsProviderTests")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("ElasticStatisticsProviderTests")]
+[assembly: AssemblyCopyright("Copyright ©  2017")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("ff4a19d7-6eae-40c5-9a4c-8013a38a3ff8")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/ElasticStatisticsProviderTests/UnitTest1.cs
+++ b/ElasticStatisticsProviderTests/UnitTest1.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace ElasticStatisticsProviderTests
+{
+    [TestClass]
+    public class UnitTest1
+    {
+        [TestMethod]
+        public void TestMethod1()
+        {
+        }
+    }
+}

--- a/OrleansElasticUtils.sln
+++ b/OrleansElasticUtils.sln
@@ -9,6 +9,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TestSilo", "TestSilo\TestSi
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ElasticStatisticsProviderTests", "ElasticStatisticsProviderTests\ElasticStatisticsProviderTests.csproj", "{FF4A19D7-6EAE-40C5-9A4C-8013A38A3FF8}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TestClient", "TestClient\TestClient\TestClient.csproj", "{E3ECAF9E-33F7-411E-9D4D-3A1DB9226C3A}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -27,6 +29,10 @@ Global
 		{FF4A19D7-6EAE-40C5-9A4C-8013A38A3FF8}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{FF4A19D7-6EAE-40C5-9A4C-8013A38A3FF8}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{FF4A19D7-6EAE-40C5-9A4C-8013A38A3FF8}.Release|Any CPU.Build.0 = Release|Any CPU
+		{E3ECAF9E-33F7-411E-9D4D-3A1DB9226C3A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E3ECAF9E-33F7-411E-9D4D-3A1DB9226C3A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E3ECAF9E-33F7-411E-9D4D-3A1DB9226C3A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{E3ECAF9E-33F7-411E-9D4D-3A1DB9226C3A}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/OrleansElasticUtils.sln
+++ b/OrleansElasticUtils.sln
@@ -7,6 +7,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "OrleansElasticUtils", "src\
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TestSilo", "TestSilo\TestSilo.csproj", "{36BBF6EF-E2CD-453D-986F-DEBEE6178DE6}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ElasticStatisticsProviderTests", "ElasticStatisticsProviderTests\ElasticStatisticsProviderTests.csproj", "{FF4A19D7-6EAE-40C5-9A4C-8013A38A3FF8}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -21,6 +23,10 @@ Global
 		{36BBF6EF-E2CD-453D-986F-DEBEE6178DE6}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{36BBF6EF-E2CD-453D-986F-DEBEE6178DE6}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{36BBF6EF-E2CD-453D-986F-DEBEE6178DE6}.Release|Any CPU.Build.0 = Release|Any CPU
+		{FF4A19D7-6EAE-40C5-9A4C-8013A38A3FF8}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{FF4A19D7-6EAE-40C5-9A4C-8013A38A3FF8}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{FF4A19D7-6EAE-40C5-9A4C-8013A38A3FF8}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{FF4A19D7-6EAE-40C5-9A4C-8013A38A3FF8}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/OrleansElasticUtils.sln
+++ b/OrleansElasticUtils.sln
@@ -5,6 +5,8 @@ VisualStudioVersion = 14.0.25420.1
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "OrleansElasticUtils", "src\OrleansElasticUtils.csproj", "{8A54E4AA-5C5E-479D-9DEB-C56A8FBB4E25}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TestSilo", "TestSilo\TestSilo.csproj", "{36BBF6EF-E2CD-453D-986F-DEBEE6178DE6}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -15,6 +17,10 @@ Global
 		{8A54E4AA-5C5E-479D-9DEB-C56A8FBB4E25}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{8A54E4AA-5C5E-479D-9DEB-C56A8FBB4E25}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{8A54E4AA-5C5E-479D-9DEB-C56A8FBB4E25}.Release|Any CPU.Build.0 = Release|Any CPU
+		{36BBF6EF-E2CD-453D-986F-DEBEE6178DE6}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{36BBF6EF-E2CD-453D-986F-DEBEE6178DE6}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{36BBF6EF-E2CD-453D-986F-DEBEE6178DE6}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{36BBF6EF-E2CD-453D-986F-DEBEE6178DE6}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/TestClient/TestClient/App.config
+++ b/TestClient/TestClient/App.config
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<configuration>
+    <startup> 
+        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5.2" />
+    </startup>
+</configuration>

--- a/TestClient/TestClient/Program.cs
+++ b/TestClient/TestClient/Program.cs
@@ -1,0 +1,41 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Text;
+using System.Threading.Tasks;
+using Orleans;
+using Orleans.Runtime.Configuration;
+using SBTech.Orleans.ElasticUtils;
+
+namespace TestClient
+{
+    class Program
+    {
+        static void Main(string[] args)
+        {
+            //ClientConfiguration config = ClientConfiguration.StandardLoad();
+
+            ClientConfiguration config = new ClientConfiguration();
+
+            config.GatewayProvider = ClientConfiguration.GatewayProviderType.Config;
+            config.Gateways.Add(new IPEndPoint(IPAddress.Loopback, 30000));
+
+
+                config.AddElasticSearchStatisticsProvider("ESSP",
+                    new Uri("http://smellycat01.devint.dev-r5ead.net:9200"));
+
+            config.StatisticsWriteLogStatisticsToTable = true;
+            config.StatisticsCollectionLevel = StatisticsLevel.Verbose3;
+            config.StatisticsLogWriteInterval = TimeSpan.FromSeconds(10);
+            config.StatisticsMetricsTableWriteInterval = TimeSpan.FromSeconds(10);
+            config.StatisticsPerfCountersWriteInterval = TimeSpan.FromSeconds(10);
+
+
+            Console.ReadLine();
+            GrainClient.Initialize(config);
+            Console.ReadLine();
+            GrainClient.Uninitialize();
+        }
+    }
+}

--- a/TestClient/TestClient/Properties/AssemblyInfo.cs
+++ b/TestClient/TestClient/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("TestClient")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("TestClient")]
+[assembly: AssemblyCopyright("Copyright ©  2017")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("e3ecaf9e-33f7-411e-9d4d-3a1db9226c3a")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/TestClient/TestClient/TestClient.csproj
+++ b/TestClient/TestClient/TestClient.csproj
@@ -4,16 +4,17 @@
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProjectGuid>{8A54E4AA-5C5E-479D-9DEB-C56A8FBB4E25}</ProjectGuid>
-    <OutputType>Library</OutputType>
+    <ProjectGuid>{E3ECAF9E-33F7-411E-9D4D-3A1DB9226C3A}</ProjectGuid>
+    <OutputType>Exe</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
-    <RootNamespace>SBTech.Orleans.ElasticUtils</RootNamespace>
-    <AssemblyName>OrleansElasticUtils</AssemblyName>
+    <RootNamespace>TestClient</RootNamespace>
+    <AssemblyName>TestClient</AssemblyName>
     <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
-    <TargetFrameworkProfile />
+    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
@@ -23,6 +24,7 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>bin\Release\</OutputPath>
@@ -31,30 +33,38 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Elasticsearch.Net, Version=1.0.0.0, Culture=neutral, PublicKeyToken=96c599bbe3e70f5d, processorArchitecture=MSIL">
-      <HintPath>..\packages\Elasticsearch.Net.1.9.0\lib\net45\Elasticsearch.Net.dll</HintPath>
+    <Reference Include="Microsoft.CodeAnalysis, Version=1.3.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.CodeAnalysis.Common.1.3.2\lib\net45\Microsoft.CodeAnalysis.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Nest, Version=1.0.0.0, Culture=neutral, PublicKeyToken=96c599bbe3e70f5d, processorArchitecture=MSIL">
-      <HintPath>..\packages\NEST.1.7.2\lib\net45\Nest.dll</HintPath>
+    <Reference Include="Microsoft.CodeAnalysis.CSharp, Version=1.3.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.CodeAnalysis.CSharp.1.3.2\lib\net45\Microsoft.CodeAnalysis.CSharp.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=7.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\packages\Newtonsoft.Json.7.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
+      <HintPath>..\..\packages\Newtonsoft.Json.7.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Orleans, Version=1.4.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Orleans.Core.1.4.0\lib\net451\Orleans.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.Orleans.Core.1.4.0\lib\net451\Orleans.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="OrleansCodeGenerator, Version=1.4.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Orleans.OrleansCodeGenerator.1.4.0\lib\net451\OrleansCodeGenerator.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="OrleansProviders, Version=1.4.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Orleans.OrleansProviders.1.4.0\lib\net451\OrleansProviders.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Collections.Immutable, Version=1.1.37.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Collections.Immutable.1.1.37\lib\dotnet\System.Collections.Immutable.dll</HintPath>
+      <HintPath>..\..\packages\System.Collections.Immutable.1.1.37\lib\dotnet\System.Collections.Immutable.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Core" />
     <Reference Include="System.Reflection.Metadata, Version=1.2.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Reflection.Metadata.1.2.0\lib\portable-net45+win8\System.Reflection.Metadata.dll</HintPath>
+      <HintPath>..\..\packages\System.Reflection.Metadata.1.2.0\lib\portable-net45+win8\System.Reflection.Metadata.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Xml.Linq" />
@@ -65,17 +75,22 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="ClientMetricsEntry.cs" />
-    <Compile Include="ElasticClientMetricsProvider.cs" />
-    <Compile Include="ElasticStatisticsProvider.cs" />
-    <Compile Include="Extensions\ProviderConfigurationExtensions.cs" />
+    <Compile Include="Program.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
-    <Compile Include="SiloMetricsEntry.cs" />
-    <Compile Include="State.cs" />
-    <Compile Include="StatsTableEntry.cs" />
   </ItemGroup>
   <ItemGroup>
+    <None Include="App.config" />
     <None Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <Analyzer Include="..\..\packages\Microsoft.CodeAnalysis.Analyzers.1.1.0\analyzers\dotnet\cs\Microsoft.CodeAnalysis.Analyzers.dll" />
+    <Analyzer Include="..\..\packages\Microsoft.CodeAnalysis.Analyzers.1.1.0\analyzers\dotnet\cs\Microsoft.CodeAnalysis.CSharp.Analyzers.dll" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\OrleansElasticUtils.csproj">
+      <Project>{8a54e4aa-5c5e-479d-9deb-c56a8fbb4e25}</Project>
+      <Name>OrleansElasticUtils</Name>
+    </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/TestClient/TestClient/packages.config
+++ b/TestClient/TestClient/packages.config
@@ -1,0 +1,21 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Microsoft.CodeAnalysis.Analyzers" version="1.1.0" targetFramework="net452" />
+  <package id="Microsoft.CodeAnalysis.Common" version="1.3.2" targetFramework="net452" />
+  <package id="Microsoft.CodeAnalysis.CSharp" version="1.3.2" targetFramework="net452" />
+  <package id="Microsoft.Orleans.Client" version="1.4.0" targetFramework="net452" />
+  <package id="Microsoft.Orleans.Core" version="1.4.0" targetFramework="net452" />
+  <package id="Microsoft.Orleans.OrleansCodeGenerator" version="1.4.0" targetFramework="net452" />
+  <package id="Microsoft.Orleans.OrleansProviders" version="1.4.0" targetFramework="net452" />
+  <package id="Newtonsoft.Json" version="7.0.1" targetFramework="net452" />
+  <package id="System.Collections" version="4.0.0" targetFramework="net452" />
+  <package id="System.Collections.Immutable" version="1.1.37" targetFramework="net452" />
+  <package id="System.Diagnostics.Debug" version="4.0.0" targetFramework="net452" />
+  <package id="System.Globalization" version="4.0.0" targetFramework="net452" />
+  <package id="System.Linq" version="4.0.0" targetFramework="net452" />
+  <package id="System.Reflection.Metadata" version="1.2.0" targetFramework="net452" />
+  <package id="System.Resources.ResourceManager" version="4.0.0" targetFramework="net452" />
+  <package id="System.Runtime" version="4.0.0" targetFramework="net452" />
+  <package id="System.Runtime.Extensions" version="4.0.0" targetFramework="net452" />
+  <package id="System.Threading" version="4.0.0" targetFramework="net452" />
+</packages>

--- a/TestSilo/App.config
+++ b/TestSilo/App.config
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<configuration>
+    <startup> 
+        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5.2" />
+    </startup>
+</configuration>

--- a/TestSilo/OrleansHostWrapper.cs
+++ b/TestSilo/OrleansHostWrapper.cs
@@ -27,6 +27,7 @@ using System.Net;
 using Orleans.Runtime.Host;
 using System.Diagnostics;
 using Orleans.Runtime.Configuration;
+using SBTech.Orleans.ElasticUtils;
 using SBTech.Orleans.Providers.Elastic;
 
 namespace TestSilo
@@ -56,8 +57,9 @@ namespace TestSilo
                 siloHost.InitializeOrleansSilo();
 
 
-                siloHost.Config.AddMemoryStorageProvider();
-                siloHost.Config.Globals.RegisterStorageProvider<ElasticStatisticsProvider>("");
+                siloHost.Config.AddElasticSearchStatisticsProvider("ESSP",
+                    new Uri("http://smellycat01.devint.dev-r5ead.net:9200"));
+                
 
 
 

--- a/TestSilo/OrleansHostWrapper.cs
+++ b/TestSilo/OrleansHostWrapper.cs
@@ -1,0 +1,227 @@
+﻿/*
+Project Orleans Cloud Service SDK ver. 1.0
+ 
+Copyright (c) Microsoft Corporation
+ 
+All rights reserved.
+ 
+MIT License
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and 
+associated documentation files (the ""Software""), to deal in the Software without restriction,
+including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense,
+and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS
+OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+using System;
+using System.Globalization;
+using System.Net;
+
+using Orleans.Runtime.Host;
+using System.Diagnostics;
+using Orleans.Runtime.Configuration;
+using SBTech.Orleans.Providers.Elastic;
+
+namespace TestSilo
+{
+    internal class OrleansHostWrapper : IDisposable
+    {
+        public bool Debug
+        {
+            get { return siloHost != null && siloHost.Debug; }
+            set { siloHost.Debug = value; }
+        }
+
+        private SiloHost siloHost;
+
+        public OrleansHostWrapper(string[] args)
+        {
+            ParseArguments(args);
+            Init();
+        }
+
+        public bool Run()
+        {
+            bool ok = false;
+
+            try
+            {
+                siloHost.InitializeOrleansSilo();
+
+
+                siloHost.Config.AddMemoryStorageProvider();
+                siloHost.Config.Globals.RegisterStorageProvider<ElasticStatisticsProvider>("");
+
+
+
+
+                ok = siloHost.StartOrleansSilo();
+
+                if (ok)
+                {
+                    Console.WriteLine(string.Format(CultureInfo.InvariantCulture, "Successfully started Orleans silo '{0}' as a {1} node.", siloHost.Name, siloHost.Type));
+                }
+                else
+                {
+                    throw new SystemException(string.Format(CultureInfo.InvariantCulture, "Failed to start Orleans silo '{0}' as a {1} node.", siloHost.Name, siloHost.Type));
+                }
+            }
+            catch (Exception exc)
+            {	//log and mute
+                siloHost.ReportStartupError(exc);
+                var msg = string.Format(CultureInfo.InvariantCulture, "{0}:\n{1}\n{2}", exc.GetType().FullName, exc.Message, exc.StackTrace);
+                Console.WriteLine(msg);
+            }
+
+            return ok;
+        }
+
+        public bool Stop()
+        {
+            bool ok = false;
+
+            try
+            {
+                siloHost.ShutdownOrleansSilo();
+
+                Console.WriteLine(string.Format(CultureInfo.InvariantCulture, "Orleans silo '{0}' shutdown.", siloHost.Name));
+            }
+            catch (Exception exc)
+            {	//log and mute
+                siloHost.ReportStartupError(exc);
+                var msg = string.Format(CultureInfo.InvariantCulture, "{0}:\n{1}\n{2}", exc.GetType().FullName, exc.Message, exc.StackTrace);
+                Console.WriteLine(msg);
+            }
+
+            return ok;
+        }
+
+        private void Init()
+        {
+            TimeSpan _timeout = Debugger.IsAttached ? TimeSpan.FromMinutes(5) : TimeSpan.FromSeconds(10);
+
+            siloHost.LoadOrleansConfig();
+
+            //do not make this silo host do the facility bootstrapper
+
+            //////////////enable the Dependency Injection
+            //////////////makes
+            ////////////siloHost.NodeConfig.StartupTypeName = typeof(FacilityStartup).AssemblyQualifiedName;
+
+            //////////////note the FacilityConfigurationClient used is specified with the startup type
+            //////////////thus if you want to Moq the interface, rather than using the FacilityStartup class
+            //////////////do so with the NodeConfig.StartupTypeName
+            ////////////siloHost.Config.Globals.RegisterBootstrapProvider<FacilityBootstrapper>("R5Facility", new Dictionary<string, string>() { { "DO-NOT-BOOTSTRAP", "true" } } );
+
+
+            //set up timeing for in debugger vs a straight run
+            siloHost.Config.Globals.ClientDropTimeout= _timeout;
+        }
+
+        private bool ParseArguments(string[] args)
+        {
+            string deploymentId = null;
+
+            string configFileName = "TestingSiloConfiguration.xml";
+            string siloName = Dns.GetHostName(); // Default to machine name
+
+            int argPos = 1;
+            for (int i = 0; i < args.Length; i++)
+            {
+                string a = args[i];
+                if (a.StartsWith("-", StringComparison.OrdinalIgnoreCase) || a.StartsWith("/", StringComparison.OrdinalIgnoreCase))
+                {
+                    switch (a.ToUpperInvariant())	//CA1308 - always use Upper, not Lower
+                    {
+                        case "/?":
+                        case "/HELP":
+                        case "-?":
+                        case "-HELP":
+                            // Query usage help
+                            return false;
+                        default:
+                            Console.WriteLine("Bad command line arguments supplied: " + a);
+                            return false;
+                    }
+                }
+                else if (a.Contains("="))
+                {
+                    string[] split = a.Split('=');
+                    if (String.IsNullOrEmpty(split[1]))
+                    {
+                        Console.WriteLine("Bad command line arguments supplied: " + a);
+                        return false;
+                    }
+                    switch (split[0].ToUpperInvariant())	//CA1308 - always use Upper, not Lower
+                    {
+                        case "DEPLOYMENTID":
+                            deploymentId = split[1];
+                            break;
+                        case "DEPLOYMENTGROUP":
+                            // TODO: Remove this at some point in future
+                            Console.WriteLine("Ignoring deprecated command line argument: " + a);
+                            break;
+                        default:
+                            Console.WriteLine("Bad command line arguments supplied: " + a);
+                            return false;
+                    }
+                }
+                // unqualified arguments below
+                else if (argPos == 1)
+                {
+                    siloName = a;
+                    argPos++;
+                }
+                else if (argPos == 2)
+                {
+                    configFileName = a;
+                    argPos++;
+                }
+                else
+                {
+                    // Too many command line arguments
+                    Console.WriteLine("Too many command line arguments supplied: " + a);
+                    return false;
+                }
+            }
+
+            siloHost = new SiloHost(siloName);
+            siloHost.ConfigFileName = configFileName;
+            if (deploymentId != null)
+                siloHost.DeploymentId = deploymentId;
+
+            return true;
+        }
+
+        public static void PrintUsage()
+        {
+            Console.WriteLine(
+@"USAGE: 
+    OrleansHost.exe [<siloName> [<configFile>]] [DeploymentId=<idString>] [/debug]
+Where:
+    <siloName>      - Name of this silo in the Config file list (optional)
+    <configFile>    - Path to the Config file to use (optional)
+    DeploymentId=<idString> 
+                    - Which deployment group this host instance should run in (optional)
+    /debug          - Turn on extra debug output during host startup (optional)");
+        }
+
+        public void Dispose()
+        {
+            Dispose(true);
+        }
+
+        protected virtual void Dispose(bool dispose)
+        {
+            siloHost.Dispose();
+            siloHost = null;
+        }
+    }
+}

--- a/TestSilo/Program.cs
+++ b/TestSilo/Program.cs
@@ -1,0 +1,49 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace TestSilo
+{
+    class Program
+    {
+        private static OrleansHostWrapper hostWrapper;
+
+        static void Main(string[] args)
+        {
+            // The Orleans silo environment is initialized in its own app domain in order to more
+            // closely emulate the distributed situation, when the client and the server cannot
+            // pass data via shared memory.
+            AppDomain hostDomain = AppDomain.CreateDomain("OrleansHost", null, new AppDomainSetup
+            {
+                AppDomainInitializer = InitSilo,
+                AppDomainInitializerArguments = args,
+            });
+
+            Console.WriteLine("Orleans Silo is running.\nPress Enter to terminate...");
+            Console.ReadLine();
+
+            hostDomain.DoCallBack(ShutdownSilo);
+        }
+
+        static void InitSilo(string[] args)
+        {
+            hostWrapper = new OrleansHostWrapper(args);
+
+            if (!hostWrapper.Run())
+            {
+                Console.Error.WriteLine("Failed to initialize Orleans silo");
+            }
+        }
+
+        static void ShutdownSilo()
+        {
+            if (hostWrapper != null)
+            {
+                hostWrapper.Dispose();
+                GC.SuppressFinalize(hostWrapper);
+            }
+        }
+    }
+}

--- a/TestSilo/Properties/AssemblyInfo.cs
+++ b/TestSilo/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("TestSilo")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("TestSilo")]
+[assembly: AssemblyCopyright("Copyright ©  2017")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("36bbf6ef-e2cd-453d-986f-debee6178de6")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/TestSilo/TestSilo.csproj
+++ b/TestSilo/TestSilo.csproj
@@ -119,6 +119,11 @@
     <Analyzer Include="..\packages\Microsoft.CodeAnalysis.Analyzers.1.1.0\analyzers\dotnet\cs\Microsoft.CodeAnalysis.Analyzers.dll" />
     <Analyzer Include="..\packages\Microsoft.CodeAnalysis.Analyzers.1.1.0\analyzers\dotnet\cs\Microsoft.CodeAnalysis.CSharp.Analyzers.dll" />
   </ItemGroup>
+  <ItemGroup>
+    <Content Include="TestingSiloConfiguration.xml">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="..\packages\Microsoft.Orleans.OrleansHost.1.4.0\build\Microsoft.Orleans.OrleansHost.targets" Condition="Exists('..\packages\Microsoft.Orleans.OrleansHost.1.4.0\build\Microsoft.Orleans.OrleansHost.targets')" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">

--- a/TestSilo/TestSilo.csproj
+++ b/TestSilo/TestSilo.csproj
@@ -1,0 +1,139 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{36BBF6EF-E2CD-453D-986F-DEBEE6178DE6}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>TestSilo</RootNamespace>
+    <AssemblyName>TestSilo</AssemblyName>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="Microsoft.CodeAnalysis, Version=1.3.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.CodeAnalysis.Common.1.3.2\lib\net45\Microsoft.CodeAnalysis.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Microsoft.CodeAnalysis.CSharp, Version=1.3.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.CodeAnalysis.CSharp.1.3.2\lib\net45\Microsoft.CodeAnalysis.CSharp.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Microsoft.Extensions.DependencyInjection, Version=1.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Extensions.DependencyInjection.1.0.0\lib\netstandard1.1\Microsoft.Extensions.DependencyInjection.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Microsoft.Extensions.DependencyInjection.Abstractions, Version=1.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Extensions.DependencyInjection.Abstractions.1.0.0\lib\netstandard1.0\Microsoft.Extensions.DependencyInjection.Abstractions.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Newtonsoft.Json, Version=7.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.7.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Orleans, Version=1.4.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Orleans.Core.1.4.0\lib\net451\Orleans.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="OrleansCodeGenerator, Version=1.4.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Orleans.OrleansCodeGenerator.1.4.0\lib\net451\OrleansCodeGenerator.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="OrleansCounterControl, Version=1.4.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Orleans.CounterControl.1.4.0\lib\net451\OrleansCounterControl.exe</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="OrleansHost, Version=1.4.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Orleans.OrleansHost.1.4.0\lib\net451\OrleansHost.exe</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="OrleansProviders, Version=1.4.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Orleans.OrleansProviders.1.4.0\lib\net451\OrleansProviders.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="OrleansRuntime, Version=1.4.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Orleans.OrleansRuntime.1.4.0\lib\net451\OrleansRuntime.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="OrleansTelemetryConsumers.Counters, Version=1.4.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Orleans.OrleansTelemetryConsumers.Counters.1.4.0\lib\net451\OrleansTelemetryConsumers.Counters.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.Collections.Immutable, Version=1.1.37.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Collections.Immutable.1.1.37\lib\dotnet\System.Collections.Immutable.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Core" />
+    <Reference Include="System.Reflection.Metadata, Version=1.2.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Reflection.Metadata.1.2.0\lib\portable-net45+win8\System.Reflection.Metadata.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="OrleansHostWrapper.cs" />
+    <Compile Include="Program.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="App.config" />
+    <None Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\src\OrleansElasticUtils.csproj">
+      <Project>{8a54e4aa-5c5e-479d-9deb-c56a8fbb4e25}</Project>
+      <Name>OrleansElasticUtils</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <Analyzer Include="..\packages\Microsoft.CodeAnalysis.Analyzers.1.1.0\analyzers\dotnet\cs\Microsoft.CodeAnalysis.Analyzers.dll" />
+    <Analyzer Include="..\packages\Microsoft.CodeAnalysis.Analyzers.1.1.0\analyzers\dotnet\cs\Microsoft.CodeAnalysis.CSharp.Analyzers.dll" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Import Project="..\packages\Microsoft.Orleans.OrleansHost.1.4.0\build\Microsoft.Orleans.OrleansHost.targets" Condition="Exists('..\packages\Microsoft.Orleans.OrleansHost.1.4.0\build\Microsoft.Orleans.OrleansHost.targets')" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\packages\Microsoft.Orleans.OrleansHost.1.4.0\build\Microsoft.Orleans.OrleansHost.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Orleans.OrleansHost.1.4.0\build\Microsoft.Orleans.OrleansHost.targets'))" />
+    <Error Condition="!Exists('..\packages\Microsoft.Orleans.CounterControl.1.4.0\build\Microsoft.Orleans.CounterControl.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Orleans.CounterControl.1.4.0\build\Microsoft.Orleans.CounterControl.targets'))" />
+  </Target>
+  <Import Project="..\packages\Microsoft.Orleans.CounterControl.1.4.0\build\Microsoft.Orleans.CounterControl.targets" Condition="Exists('..\packages\Microsoft.Orleans.CounterControl.1.4.0\build\Microsoft.Orleans.CounterControl.targets')" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/TestSilo/TestingSiloConfiguration.xml
+++ b/TestSilo/TestingSiloConfiguration.xml
@@ -1,0 +1,27 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<OrleansConfiguration xmlns="urn:orleans">
+  <Globals>
+    <StreamProviders>
+      <Provider Type="Orleans.Providers.Streams.SimpleMessageStream.SimpleMessageStreamProvider"
+          Name="SMS"
+          FireAndForgetDelivery="false"/>
+    </StreamProviders>
+
+    <StorageProviders>
+      <Provider Type="Orleans.Storage.MemoryStorage" Name="PubSubStore" />
+    </StorageProviders>
+    <SeedNode Address="localhost" Port="11111" />
+  </Globals>
+  <Defaults>
+    <Networking Address="localhost" Port="11111" />
+    <ProxyingGateway Address="localhost" Port="30000" />
+    <Tracing
+      DefaultTraceLevel="Verbose"
+      TraceToConsole="true"
+      TraceToFile="{2}-{0}-{1}.log"
+      BulkMessageLimit="1000">
+      <!--<TraceLevelOverride LogPrefix="Application" TraceLevel="Info" />-->
+      <TraceLevelOverride LogPrefix="Runtime" TraceLevel="Info" />
+    </Tracing>
+  </Defaults>
+</OrleansConfiguration>

--- a/TestSilo/packages.config
+++ b/TestSilo/packages.config
@@ -1,0 +1,32 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Microsoft.CodeAnalysis.Analyzers" version="1.1.0" targetFramework="net452" />
+  <package id="Microsoft.CodeAnalysis.Common" version="1.3.2" targetFramework="net452" />
+  <package id="Microsoft.CodeAnalysis.CSharp" version="1.3.2" targetFramework="net452" />
+  <package id="Microsoft.Extensions.DependencyInjection" version="1.0.0" targetFramework="net452" />
+  <package id="Microsoft.Extensions.DependencyInjection.Abstractions" version="1.0.0" targetFramework="net452" />
+  <package id="Microsoft.Orleans.Core" version="1.4.0" targetFramework="net452" />
+  <package id="Microsoft.Orleans.CounterControl" version="1.4.0" targetFramework="net452" />
+  <package id="Microsoft.Orleans.OrleansCodeGenerator" version="1.4.0" targetFramework="net452" />
+  <package id="Microsoft.Orleans.OrleansHost" version="1.4.0" targetFramework="net452" />
+  <package id="Microsoft.Orleans.OrleansProviders" version="1.4.0" targetFramework="net452" />
+  <package id="Microsoft.Orleans.OrleansRuntime" version="1.4.0" targetFramework="net452" />
+  <package id="Microsoft.Orleans.OrleansTelemetryConsumers.Counters" version="1.4.0" targetFramework="net452" />
+  <package id="Microsoft.Orleans.Server" version="1.4.0" targetFramework="net452" />
+  <package id="Newtonsoft.Json" version="7.0.1" targetFramework="net452" />
+  <package id="System.Collections" version="4.0.11" targetFramework="net452" />
+  <package id="System.Collections.Concurrent" version="4.0.12" targetFramework="net452" />
+  <package id="System.Collections.Immutable" version="1.1.37" targetFramework="net452" />
+  <package id="System.ComponentModel" version="4.0.1" targetFramework="net452" />
+  <package id="System.Diagnostics.Debug" version="4.0.11" targetFramework="net452" />
+  <package id="System.Globalization" version="4.0.11" targetFramework="net452" />
+  <package id="System.Linq" version="4.1.0" targetFramework="net452" />
+  <package id="System.Linq.Expressions" version="4.1.0" targetFramework="net452" />
+  <package id="System.Reflection" version="4.1.0" targetFramework="net452" />
+  <package id="System.Reflection.Metadata" version="1.2.0" targetFramework="net452" />
+  <package id="System.Resources.ResourceManager" version="4.0.1" targetFramework="net452" />
+  <package id="System.Runtime" version="4.0.0" targetFramework="net452" />
+  <package id="System.Runtime.Extensions" version="4.1.0" targetFramework="net452" />
+  <package id="System.Threading" version="4.0.11" targetFramework="net452" />
+  <package id="System.Threading.Tasks" version="4.0.11" targetFramework="net452" />
+</packages>

--- a/src/ClientMetricsEntry.cs
+++ b/src/ClientMetricsEntry.cs
@@ -1,0 +1,20 @@
+﻿namespace SBTech.Orleans.Providers.Elastic
+{
+    internal class ClientMetricsEntry
+    {
+        public string Address { get; set; }
+        public long AvailablePhysicalMemory { get; set; }
+        public string ClientId { get; set; }
+        public long ConnectedGatewayCount { get; set; }
+        public float CpuUsage { get; set; }
+        public string DeploymentId { get; set; }
+        public string HostName { get; set; }
+        public long MemoryUsage { get; set; }
+        public long ReceivedMessages { get; set; }
+        public int ReceiveQueueLength { get; set; }
+        public int SendQueueLength { get; set; }
+        public long SentMessages { get; set; }
+        public string Time { get; set; }
+        public long TotalPhysicalMemory { get; set; }
+    }
+}

--- a/src/ElasticClientMetricsProvider.cs
+++ b/src/ElasticClientMetricsProvider.cs
@@ -1,0 +1,256 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Net;
+using System.Threading.Tasks;
+using Orleans;
+using Orleans.Runtime;
+using Orleans.Providers;
+using Nest;
+using Orleans.Runtime.Configuration;
+
+namespace SBTech.Orleans.Providers.Elastic
+{
+    public class ElasticClientMetricsProvider : IClientMetricsDataPublisher,
+                                             IStatisticsPublisher,
+                                             IProvider
+    {
+        // Example: 2010-09-02 09:50:43.341 GMT - Variant of UniversalSorta­bleDateTimePat­tern
+        const string DATE_TIME_FORMAT = "yyyy-MM-dd-" + "HH:mm:ss.fff 'GMT'";        
+        int MAX_BULK_UPDATE_DOCS = 200;
+        State _state = new State();
+        Logger _logger;   
+
+        /// <summary>
+        /// Name of the provider
+        /// </summary>
+        public string Name { get; private set; }
+
+        /// <summary>
+        /// Closes provider
+        /// </summary>        
+        public Task Close() => TaskDone.Done;
+
+        /// <summary>
+        /// Initialization of ElasticStatisticsProvider
+        /// </summary>        
+        public Task Init(string name, IProviderRuntime providerRuntime, IProviderConfiguration config)
+        {            
+            Name = name;
+            _state.Id = providerRuntime.SiloIdentity;
+            _logger = providerRuntime.GetLogger(typeof(ElasticStatisticsProvider).Name);
+            
+            if (config.Properties.ContainsKey("ElasticHostAddress"))
+                _state.ElasticHostAddress = config.Properties["ElasticHostAddress"];
+
+            if (config.Properties.ContainsKey("ElasticIndex"))
+                _state.ElasticIndex = config.Properties["ElasticIndex"];
+
+            if (config.Properties.ContainsKey("ElasticMetricsType"))
+                _state.ElasticMetricsType = config.Properties["ElasticMetricsType"];
+
+            if (config.Properties.ContainsKey("ElasticStatsType"))
+                _state.ElasticStatsType = config.Properties["ElasticStatsType"];
+
+            return TaskDone.Done;
+        }
+
+        /// <summary>
+        /// Initialization of configuration for Silo
+        /// </summary>        
+        public void AddConfiguration(string deploymentId, bool isSilo, string siloName, SiloAddress address, IPEndPoint gateway, string hostName)
+        {            
+            _state.DeploymentId = deploymentId;
+            _state.IsSilo = isSilo;
+            _state.SiloName = siloName;
+            _state.Address = address.ToString();
+            _state.GatewayAddress = gateway.ToString();
+            _state.HostName = hostName;            
+        }
+
+        /// <summary>
+        /// Metrics for Silo
+        /// </summary>        
+        public async Task ReportMetrics(ISiloPerformanceMetrics metricsData)
+        {
+            if (_logger != null && _logger.IsVerbose3)
+                _logger.Verbose3("ElasticStatisticsProvider.ReportMetrics called with metrics: {0}, name: {1}, id: {2}.", metricsData, _state.SiloName, _state.Id);
+
+            try
+            {
+                var esClient = CreateElasticClient(_state.ElasticHostAddress);
+
+                var siloMetrics = PopulateSiloMetricsEntry(metricsData, _state);
+
+                var response = await esClient.IndexAsync(siloMetrics, (ds) => ds.Index(_state.ElasticIndex)
+                                                                                .Type(_state.ElasticMetricsType));
+
+                if (!response.IsValid && _logger != null && _logger.IsVerbose)
+                    _logger.Verbose(response.ServerError.Status, response.ServerError.Error);
+            }
+            catch (Exception ex)
+            {
+                if (_logger != null && _logger.IsVerbose)
+                    _logger.Verbose("ElasticStatisticsProvider.ReportMetrics failed: {0}", ex);
+
+                throw;
+            }
+        }
+
+        /// <summary>
+        /// Stats for Silo and Client
+        /// </summary>  
+        public async Task ReportStats(List<ICounter> statsCounters)
+        {
+            if (_logger != null && _logger.IsVerbose3)
+                _logger.Verbose3("ElasticStatisticsProvider.ReportStats called with {0} counters, name: {1}, id: {2}", statsCounters.Count, _state.SiloName, _state.Id);
+
+            try
+            {
+                var esClient = CreateElasticClient(_state.ElasticHostAddress);
+
+                var counterBatches = statsCounters.Where(cs => cs.Storage == CounterStorage.LogAndTable)
+                                                  .OrderBy(cs => cs.Name)
+                                                  .Select(cs => PopulateStatsTableEntry(cs, _state))
+                                                  .BatchIEnumerable(MAX_BULK_UPDATE_DOCS);
+
+                foreach (var batch in counterBatches)
+                {
+                    var bulkDesc = new BulkDescriptor();
+                    bulkDesc.CreateMany(batch, (bulk, q) => bulk.Index(_state.ElasticIndex)
+                                                                .Type(_state.ElasticStatsType));
+
+                    var response = await esClient.BulkAsync(bulkDesc);
+
+                    if (response.Errors && _logger != null && _logger.IsVerbose)
+                        _logger.Error(response.ServerError.Status, response.ServerError.Error);
+                }
+            }
+            catch (Exception ex)
+            {
+                if (_logger != null && _logger.IsVerbose)
+                    _logger.Verbose("ElasticStatisticsProvider.ReportStats failed: {0}", ex);
+
+                throw;
+            }
+        }
+
+        public Task Init(string deploymentId, string storageConnectionString, SiloAddress siloAddress, string siloName, IPEndPoint gateway, string hostName) => TaskDone.Done;
+
+        public Task Init(bool isSilo, string storageConnectionString, string deploymentId, string address, string siloName, string hostName) => TaskDone.Done;
+
+        static ElasticClient CreateElasticClient(string elasticHostAddress)
+        {            
+            var node = new Uri(elasticHostAddress);
+            return new ElasticClient(new ConnectionSettings(node));
+        }       
+
+        static SiloMetricsEntry PopulateSiloMetricsEntry(ISiloPerformanceMetrics metricsData, State state)
+        {
+            return new SiloMetricsEntry
+            {
+                SiloId = state.Id,
+                SiloName = state.SiloName,
+                DeploymentId = state.DeploymentId,
+                Address = state.Address,
+                HostName = state.HostName,
+                GatewayAddress = state.GatewayAddress,
+                CpuUsage = metricsData.CpuUsage,
+                TotalPhysicalMemory = metricsData.TotalPhysicalMemory,
+                AvailablePhysicalMemory = metricsData.AvailablePhysicalMemory,
+                MemoryUsage = metricsData.MemoryUsage,
+                SendQueueLength = metricsData.SendQueueLength,
+                ReceiveQueueLength = metricsData.ReceiveQueueLength,
+                SentMessages = metricsData.SentMessages,
+                ReceivedMessages = metricsData.ReceivedMessages,
+                ActivationsCount = metricsData.ActivationCount,
+                RecentlyUsedActivations = metricsData.RecentlyUsedActivationCount,
+                RequestQueueLength = metricsData.ReceiveQueueLength,
+                IsOverloaded = metricsData.IsOverloaded,
+                ClientCount = metricsData.ClientCount,
+                Time = DateTime.UtcNow.ToString(DATE_TIME_FORMAT, CultureInfo.InvariantCulture)                
+            };
+        }
+
+        static StatsTableEntry PopulateStatsTableEntry(ICounter counter, State state)
+        {
+            return new StatsTableEntry
+            {
+                Identity = state.Id,
+                DeploymentId = state.DeploymentId,                
+                Name = state.SiloName,
+                HostName = state.HostName,
+                Statistic = counter.Name,
+                IsDelta = counter.IsValueDelta,
+                StatValue = counter.IsValueDelta ? counter.GetDeltaString() : counter.GetValueString(),
+                Time = DateTime.UtcNow.ToString(DATE_TIME_FORMAT, CultureInfo.InvariantCulture)
+            };
+        }
+
+        public Task Init(ClientConfiguration config, IPAddress address, string clientId)
+        {
+            throw new NotImplementedException();
+        }
+
+        public Task ReportMetrics(IClientPerformanceMetrics metricsData)
+        {
+            throw new NotImplementedException();
+        }
+    }
+
+    //class State
+    //{
+    //    public string DeploymentId { get; set; } = "";
+    //    public bool IsSilo { get; set; } = true;
+    //    public string SiloName { get; set; } = "";
+    //    public string Id { get; set; } = "";
+    //    public string Address { get; set; } = "";
+    //    public string GatewayAddress { get; set; } = "";
+    //    public string HostName { get; set; } = "";
+    //    public string ElasticHostAddress { get; set; } = "http://localhost:9200";
+    //    public string ElasticIndex { get; set; } = "orleans_statistics";
+    //    public string ElasticMetricsType { get; set; } = "metrics";
+    //    public string ElasticStatsType { get; set; } = "stats";
+    //}
+
+    //[Serializable]
+    //internal class StatsTableEntry
+    //{
+    //    public string Identity { get; set; }        
+    //    public string DeploymentId { get; set; }        
+    //    public string Name { get; set; }        
+    //    public string HostName { get; set; }
+    //    public string Statistic { get; set; }
+    //    public string StatValue { get; set; }
+    //    public bool IsDelta { get; set; }
+    //    public string Time { get; set; }
+    //    public override string ToString() => $"StatsTableEntry[ Identity={Identity} DeploymentId={DeploymentId} Name={Name} HostName={HostName} Statistic={Statistic} StatValue={StatValue} IsDelta={IsDelta} Time={Time} ]";
+    //}
+
+    //[Serializable]
+    //internal class SiloMetricsEntry
+    //{
+    //    public string SiloId { get; set; }
+    //    public string SiloName { get; set; }
+    //    public string DeploymentId { get; set; }
+    //    public string Address { get; set; }
+    //    public string HostName { get; set; }
+    //    public string GatewayAddress { get; set; }
+    //    public double CpuUsage { get; set; }
+    //    public long TotalPhysicalMemory { get; set; }
+    //    public long AvailablePhysicalMemory { get; set; }        
+    //    public long MemoryUsage { get; set; }
+    //    public int SendQueueLength { get; set; }
+    //    public int ReceiveQueueLength { get; set; }
+    //    public long SentMessages { get; set; }
+    //    public long ReceivedMessages { get; set; }
+    //    public int ActivationsCount { get; set; }
+    //    public int RecentlyUsedActivations { get; set; }
+    //    public int RequestQueueLength { get; set; }
+    //    public bool IsOverloaded { get; set; }
+    //    public long ClientCount { get; set; }
+    //    public string Time { get; set; }
+    //    public override string ToString() => $"SiloMetricsEntry[ SiloId={SiloId} DeploymentId={DeploymentId} Address={Address} HostName={HostName} GatewayAddress={GatewayAddress} CpuUsage={CpuUsage} TotalPhysicalMemory={TotalPhysicalMemory} AvailablePhysicalMemory={AvailablePhysicalMemory} MemoryUsage={MemoryUsage} SendQueueLength={SendQueueLength} ReceiveQueueLength={ReceiveQueueLength} SentMessages={SentMessages} ReceivedMessages={ReceivedMessages} ActivationsCount={ActivationsCount} RecentlyUsedActivations={RecentlyUsedActivations} RequestQueueLength={RequestQueueLength} IsOverloaded={IsOverloaded} ClientCount={ClientCount} Time={Time} ]";
+    //}
+}

--- a/src/ElasticStatisticsProvider.cs
+++ b/src/ElasticStatisticsProvider.cs
@@ -121,7 +121,7 @@ namespace SBTech.Orleans.Providers.Elastic
         public async Task ReportMetrics(ISiloPerformanceMetrics metricsData)
         {
             if (_logger != null && _logger.IsVerbose3)
-                _logger.Verbose3("ElasticStatisticsProvider.ReportMetrics called with metrics: {0}, name: {1}, id: {2}.", metricsData, _state.SiloName, _state.Id);
+                _logger.Verbose3($"{ nameof(ElasticStatisticsProvider)}.ReportMetrics called with metrics: {0}, name: {1}, id: {2}.", metricsData, _state.SiloName, _state.Id);
 
             try
             {
@@ -137,7 +137,7 @@ namespace SBTech.Orleans.Providers.Elastic
             catch (Exception ex)
             {
                 if (_logger != null && _logger.IsVerbose)
-                    _logger.Verbose("ElasticStatisticsProvider.ReportMetrics failed: {0}", ex);
+                    _logger.Verbose($"{ nameof(ElasticStatisticsProvider)}.ReportMetrics failed: {0}", ex);
 
                 throw;
             }
@@ -149,7 +149,7 @@ namespace SBTech.Orleans.Providers.Elastic
         public async Task ReportStats(List<ICounter> statsCounters)
         {
             if (_logger != null && _logger.IsVerbose3)
-                _logger.Verbose3("ElasticStatisticsProvider.ReportStats called with {0} counters, name: {1}, id: {2}", statsCounters.Count, _state.SiloName, _state.Id);
+                _logger.Verbose3($"{ nameof(ElasticStatisticsProvider)}.ReportStats called with {0} counters, name: {1}, id: {2}", statsCounters.Count, _state.SiloName, _state.Id);
 
             try
             {
@@ -174,7 +174,7 @@ namespace SBTech.Orleans.Providers.Elastic
             catch (Exception ex)
             {
                 if (_logger != null && _logger.IsVerbose)
-                    _logger.Verbose("ElasticStatisticsProvider.ReportStats failed: {0}", ex);
+                    _logger.Verbose($"{ nameof(ElasticStatisticsProvider)}.ReportStats failed: {0}", ex);
 
                 throw;
             }
@@ -224,22 +224,9 @@ namespace SBTech.Orleans.Providers.Elastic
             stat.Add("DeploymentId", state.DeploymentId);
             stat.Add("HostName", state.HostName);
             stat.Add("UtcDateTime", DateTimeOffset.UtcNow.UtcDateTime);
-            stat.Add(counter.Name, counter.IsValueDelta ? counter.GetDeltaString() : counter.GetValueString());
+            stat.Add(counter.Name, counter.IsValueDelta ? float.Parse(counter.GetDeltaString()): float.Parse(counter.GetValueString()));
 
             return stat;
-
-            //return new StatsTableEntry
-            //{
-            //    Identity = state.Id,
-            //    DeploymentId = state.DeploymentId,                
-            //    Name = state.SiloName,
-            //    HostName = state.HostName,
-            //    Statistic = counter.Name,
-            //    IsDelta = counter.IsValueDelta,
-            //    StatValue = counter.IsValueDelta ? counter.GetDeltaString() : counter.GetValueString(),
-            //    Time = DateTime.UtcNow.ToString(DATE_TIME_FORMAT, CultureInfo.InvariantCulture),
-            //    UtcDateTime = DateTimeOffset.UtcNow.UtcDateTime
-            //};
         }
     }
 }

--- a/src/Extensions/ProviderConfigurationExtensions.cs
+++ b/src/Extensions/ProviderConfigurationExtensions.cs
@@ -10,17 +10,6 @@ namespace SBTech.Orleans.ElasticUtils
 {
     public static class ProviderConfigurationExtensions
     {
-        //
-        // Summary:
-        //     Adds a storage provider of type Orleans.Storage.MemoryStorage
-        //
-        // Parameters:
-        //   config:
-        //     The cluster configuration object to add provider to.
-        //
-        //   providerName:
-        //     The provider name.
-        //
         public static void AddElasticSearchStatisticsProvider(this ClusterConfiguration config,
             string providerName, Uri ElasticHostAddress, string ElasticIndex= "orleans_statistics", string ElasticMetricType= "metric", string ElasticCounterType = "counter")
         {

--- a/src/Extensions/ProviderConfigurationExtensions.cs
+++ b/src/Extensions/ProviderConfigurationExtensions.cs
@@ -22,43 +22,39 @@ namespace SBTech.Orleans.ElasticUtils
         //     The provider name.
         //
         public static void AddElasticSearchStatisticsProvider(this ClusterConfiguration config,
-            string providerName, Uri ElasticHostAddress, string ElasticIndex= "orleans_statistics", string ElasticMetricsType= "silo_metrics",
-            string ElasticStatsType="silo_stats")
+            string providerName, Uri ElasticHostAddress, string ElasticIndex= "orleans_statistics", string ElasticMetricType= "metric", string ElasticCounterType = "counter")
         {
             if (string.IsNullOrWhiteSpace(providerName)) throw new ArgumentNullException(nameof(providerName));
             if (string.IsNullOrWhiteSpace(ElasticIndex)) throw new ArgumentNullException(nameof(ElasticIndex));
-            if (string.IsNullOrWhiteSpace(ElasticMetricsType)) throw new ArgumentNullException(nameof(ElasticMetricsType));
-            if (string.IsNullOrWhiteSpace(ElasticStatsType)) throw new ArgumentNullException(nameof(ElasticStatsType));
+            if (string.IsNullOrWhiteSpace(ElasticMetricType)) throw new ArgumentNullException(nameof(ElasticMetricType));
+            if (string.IsNullOrWhiteSpace(ElasticCounterType)) throw new ArgumentNullException(nameof(ElasticCounterType));
 
             var properties = new Dictionary<string, string>
             {
                 {"ElasticHostAddress", ElasticHostAddress.ToString()},
                 {"ElasticIndex", ElasticIndex},
-                {"ElasticMetricsType", ElasticMetricsType},
-                {"ElasticStatsType", ElasticStatsType}
+                {"ElasticMetricsType", ElasticMetricType},
+                {"ElasticCounterType", ElasticCounterType},
             };
 
             config.Globals.RegisterStatisticsProvider<ElasticStatisticsProvider>(providerName, properties);
         }
 
         public static void AddElasticSearchStatisticsProvider(this ClientConfiguration config,
-            string providerName, Uri ElasticHostAddress, string ElasticIndex = "orleans_statistics", string ElasticMetricsType = "silo_metrics",
-            string ElasticStatsType = "silo_stats")
+            string providerName, Uri ElasticHostAddress, string ElasticIndex = "orleans_statistics", string ElasticType = "metrics")
         {
             if (string.IsNullOrWhiteSpace(providerName)) throw new ArgumentNullException(nameof(providerName));
             if (string.IsNullOrWhiteSpace(ElasticIndex)) throw new ArgumentNullException(nameof(ElasticIndex));
-            if (string.IsNullOrWhiteSpace(ElasticMetricsType)) throw new ArgumentNullException(nameof(ElasticMetricsType));
-            if (string.IsNullOrWhiteSpace(ElasticStatsType)) throw new ArgumentNullException(nameof(ElasticStatsType));
+            if (string.IsNullOrWhiteSpace(ElasticType)) throw new ArgumentNullException(nameof(ElasticType));
 
             var properties = new Dictionary<string, string>
             {
                 {"ElasticHostAddress", ElasticHostAddress.ToString()},
                 {"ElasticIndex", ElasticIndex},
-                {"ElasticMetricsType", ElasticMetricsType},
-                {"ElasticStatsType", ElasticStatsType}
+                {"ElasticMetricsType", ElasticType},
             };
 
-            config.RegisterStatisticsProvider<ElasticStatisticsProvider>(providerName, properties);
+            config.RegisterStatisticsProvider<ElasticClientMetricsProvider>(providerName, properties);
         }
 
     }

--- a/src/Extensions/ProviderConfigurationExtensions.cs
+++ b/src/Extensions/ProviderConfigurationExtensions.cs
@@ -1,0 +1,65 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Orleans.Runtime.Configuration;
+using SBTech.Orleans.Providers.Elastic;
+
+namespace SBTech.Orleans.ElasticUtils
+{
+    public static class ProviderConfigurationExtensions
+    {
+        //
+        // Summary:
+        //     Adds a storage provider of type Orleans.Storage.MemoryStorage
+        //
+        // Parameters:
+        //   config:
+        //     The cluster configuration object to add provider to.
+        //
+        //   providerName:
+        //     The provider name.
+        //
+        public static void AddElasticSearchStatisticsProvider(this ClusterConfiguration config,
+            string providerName, Uri ElasticHostAddress, string ElasticIndex= "orleans_statistics", string ElasticMetricsType= "silo_metrics",
+            string ElasticStatsType="silo_stats")
+        {
+            if (string.IsNullOrWhiteSpace(providerName)) throw new ArgumentNullException(nameof(providerName));
+            if (string.IsNullOrWhiteSpace(ElasticIndex)) throw new ArgumentNullException(nameof(ElasticIndex));
+            if (string.IsNullOrWhiteSpace(ElasticMetricsType)) throw new ArgumentNullException(nameof(ElasticMetricsType));
+            if (string.IsNullOrWhiteSpace(ElasticStatsType)) throw new ArgumentNullException(nameof(ElasticStatsType));
+
+            var properties = new Dictionary<string, string>
+            {
+                {"ElasticHostAddress", ElasticHostAddress.ToString()},
+                {"ElasticIndex", ElasticIndex},
+                {"ElasticMetricsType", ElasticMetricsType},
+                {"ElasticStatsType", ElasticStatsType}
+            };
+
+            config.Globals.RegisterStatisticsProvider<ElasticStatisticsProvider>(providerName, properties);
+        }
+
+        public static void AddElasticSearchStatisticsProvider(this ClientConfiguration config,
+            string providerName, Uri ElasticHostAddress, string ElasticIndex = "orleans_statistics", string ElasticMetricsType = "silo_metrics",
+            string ElasticStatsType = "silo_stats")
+        {
+            if (string.IsNullOrWhiteSpace(providerName)) throw new ArgumentNullException(nameof(providerName));
+            if (string.IsNullOrWhiteSpace(ElasticIndex)) throw new ArgumentNullException(nameof(ElasticIndex));
+            if (string.IsNullOrWhiteSpace(ElasticMetricsType)) throw new ArgumentNullException(nameof(ElasticMetricsType));
+            if (string.IsNullOrWhiteSpace(ElasticStatsType)) throw new ArgumentNullException(nameof(ElasticStatsType));
+
+            var properties = new Dictionary<string, string>
+            {
+                {"ElasticHostAddress", ElasticHostAddress.ToString()},
+                {"ElasticIndex", ElasticIndex},
+                {"ElasticMetricsType", ElasticMetricsType},
+                {"ElasticStatsType", ElasticStatsType}
+            };
+
+            config.RegisterStatisticsProvider<ElasticStatisticsProvider>(providerName, properties);
+        }
+
+    }
+}

--- a/src/OrleansElasticUtils.csproj
+++ b/src/OrleansElasticUtils.csproj
@@ -43,12 +43,20 @@
       <HintPath>..\packages\Newtonsoft.Json.7.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Orleans, Version=1.2.3.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Orleans.Core.1.2.3\lib\net451\Orleans.dll</HintPath>
+    <Reference Include="Orleans, Version=1.4.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Orleans.Core.1.4.0\lib\net451\Orleans.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />
+    <Reference Include="System.Collections.Immutable, Version=1.1.37.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Collections.Immutable.1.1.37\lib\dotnet\System.Collections.Immutable.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="System.Core" />
+    <Reference Include="System.Reflection.Metadata, Version=1.2.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Reflection.Metadata.1.2.0\lib\portable-net45+win8\System.Reflection.Metadata.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />
@@ -57,7 +65,9 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="ElasticClientMetricsProvider.cs" />
     <Compile Include="ElasticStatisticsProvider.cs" />
+    <Compile Include="Extensions\ProviderConfigurationExtensions.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/src/OrleansElasticUtils.csproj
+++ b/src/OrleansElasticUtils.csproj
@@ -69,6 +69,9 @@
     <Compile Include="ElasticStatisticsProvider.cs" />
     <Compile Include="Extensions\ProviderConfigurationExtensions.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="SiloMetricsEntry.cs" />
+    <Compile Include="State.cs" />
+    <Compile Include="StatsTableEntry.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />

--- a/src/SiloMetricsEntry.cs
+++ b/src/SiloMetricsEntry.cs
@@ -1,0 +1,32 @@
+﻿using System;
+
+namespace SBTech.Orleans.Providers.Elastic
+{
+    [Serializable]
+    internal class SiloMetricsEntry
+    {
+        public string SiloId { get; set; }
+        public string SiloName { get; set; }
+        public string DeploymentId { get; set; }
+        public string Address { get; set; }
+        public string HostName { get; set; }
+        public string GatewayAddress { get; set; }
+        public double CpuUsage { get; set; }
+        public long TotalPhysicalMemory { get; set; }
+        public long AvailablePhysicalMemory { get; set; }        
+        public long MemoryUsage { get; set; }
+        public int SendQueueLength { get; set; }
+        public int ReceiveQueueLength { get; set; }
+        public long SentMessages { get; set; }
+        public long ReceivedMessages { get; set; }
+        public int ActivationsCount { get; set; }
+        public int RecentlyUsedActivations { get; set; }
+        public int RequestQueueLength { get; set; }
+        public bool IsOverloaded { get; set; }
+        public long ClientCount { get; set; }
+        public string Time { get; set; }
+        public DateTime UtcDateTime { get; set; }
+
+        public override string ToString() => $"SiloMetricsEntry[ SiloId={SiloId} DeploymentId={DeploymentId} Address={Address} HostName={HostName} GatewayAddress={GatewayAddress} CpuUsage={CpuUsage} TotalPhysicalMemory={TotalPhysicalMemory} AvailablePhysicalMemory={AvailablePhysicalMemory} MemoryUsage={MemoryUsage} SendQueueLength={SendQueueLength} ReceiveQueueLength={ReceiveQueueLength} SentMessages={SentMessages} ReceivedMessages={ReceivedMessages} ActivationsCount={ActivationsCount} RecentlyUsedActivations={RecentlyUsedActivations} RequestQueueLength={RequestQueueLength} IsOverloaded={IsOverloaded} ClientCount={ClientCount} Time={Time} ]";
+    }
+}

--- a/src/State.cs
+++ b/src/State.cs
@@ -1,0 +1,16 @@
+﻿using System;
+
+namespace SBTech.Orleans.Providers.Elastic
+{
+    class State
+    {
+        public string DeploymentId { get; set; } = "";
+        public bool IsSilo { get; set; } = true;
+        public string SiloName { get; set; } = "";
+        public string Id { get; set; } = "";
+        public string Address { get; set; } = "";
+        public string GatewayAddress { get; set; } = "";
+        public string HostName { get; set; } = "";
+        public Guid ServiceId { get; set; } = Guid.Empty;
+    }
+}

--- a/src/StatsTableEntry.cs
+++ b/src/StatsTableEntry.cs
@@ -1,0 +1,20 @@
+﻿using System;
+
+namespace SBTech.Orleans.Providers.Elastic
+{
+    [Serializable]
+    internal class StatsTableEntry
+    {
+        public string Identity { get; set; }        
+        public string DeploymentId { get; set; }        
+        public string Name { get; set; }        
+        public string HostName { get; set; }
+        public string Statistic { get; set; }
+        public string StatValue { get; set; }
+        public bool IsDelta { get; set; }
+        public string Time { get; set; }
+        public DateTime UtcDateTime { get; set; }
+
+        public override string ToString() => $"StatsTableEntry[ Identity={Identity} DeploymentId={DeploymentId} Name={Name} HostName={HostName} Statistic={Statistic} StatValue={StatValue} IsDelta={IsDelta} Time={Time} ]";
+    }
+}

--- a/src/packages.config
+++ b/src/packages.config
@@ -1,7 +1,17 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Elasticsearch.Net" version="1.9.0" targetFramework="net451" />
-  <package id="Microsoft.Orleans.Core" version="1.2.3" targetFramework="net451" />
+  <package id="Microsoft.Orleans.Core" version="1.4.0" targetFramework="net452" />
   <package id="NEST" version="1.7.2" targetFramework="net451" />
   <package id="Newtonsoft.Json" version="7.0.1" targetFramework="net451" />
+  <package id="System.Collections" version="4.0.0" targetFramework="net452" />
+  <package id="System.Collections.Immutable" version="1.1.37" targetFramework="net452" />
+  <package id="System.Diagnostics.Debug" version="4.0.0" targetFramework="net452" />
+  <package id="System.Globalization" version="4.0.0" targetFramework="net452" />
+  <package id="System.Linq" version="4.0.0" targetFramework="net452" />
+  <package id="System.Reflection.Metadata" version="1.2.0" targetFramework="net452" />
+  <package id="System.Resources.ResourceManager" version="4.0.0" targetFramework="net452" />
+  <package id="System.Runtime" version="4.0.0" targetFramework="net452" />
+  <package id="System.Runtime.Extensions" version="4.0.0" targetFramework="net452" />
+  <package id="System.Threading" version="4.0.0" targetFramework="net452" />
 </packages>


### PR DESCRIPTION
bump to 1.4.0
client statistics provider
change Icounter to use the name as the key
Bulk CreateIndex change (was throwing a 400)
no unit tests, yet

I would really like this to be copied into the OrleansContrib repo and nuget'd from there.  Do you think that's possible?
